### PR TITLE
Call onDismiss when FullscreenView is dismissed

### DIFF
--- a/Sources/Presentation/Fullscreen.swift
+++ b/Sources/Presentation/Fullscreen.swift
@@ -9,10 +9,11 @@ internal struct FullscreenView<Content: View>: UIViewControllerRepresentable {
     let isModal: Bool
     let transition: UIModalTransitionStyle
     let style: UIModalPresentationStyle
+    let onDismiss: (() -> Void)?
     let content: () -> Content
 
     func makeUIViewController(context: Context) -> UIViewController {
-        FullscreenWrapper(isPresented: isPresented, content: content)
+        FullscreenWrapper(isPresented: isPresented, onDismiss: onDismiss, content: content)
     }
 
     func updateUIViewController(_ controller: UIViewController, context: Context) {
@@ -21,6 +22,7 @@ internal struct FullscreenView<Content: View>: UIViewControllerRepresentable {
         controller.isModal = isModal
         controller.transition = transition
         controller.style = style
+        controller.onDismiss = onDismiss
         controller.content = content
         controller.presentIfNeeded()
     }
@@ -32,11 +34,13 @@ private final class FullscreenWrapper<Content: View>: UIViewController {
     var isModal: Bool = false
     var transition: UIModalTransitionStyle = .coverVertical
     var style: UIModalPresentationStyle = .pageSheet
+    var onDismiss: (() -> Void)?
     var content: () -> Content
     private var cancel: AnyCancellable?
 
-    init(isPresented: Binding<Bool>, content: @escaping () -> Content) {
+    init(isPresented: Binding<Bool>, onDismiss: (() -> Void)?, content: @escaping () -> Content) {
         self.isPresented = isPresented
+        self.onDismiss = onDismiss
         self.content = content
         super.init(nibName: nil, bundle: nil)
     }
@@ -57,6 +61,7 @@ private final class FullscreenWrapper<Content: View>: UIViewController {
             if !isAlreadyPresented {
                 let controller = viewController(rootView: content(), isModal: isModal, transition: transition, style: style) { [weak self] in
                     self?.isPresented.wrappedValue = false
+                    self?.onDismiss?()
                 }
                 present(controller, animated: true)
             }

--- a/Sources/Presentation/View+Fullscreen.swift
+++ b/Sources/Presentation/View+Fullscreen.swift
@@ -18,7 +18,7 @@ public extension View {
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder content: @escaping () -> Content
     ) -> some View where Content: View {
-        background(FullscreenView(isPresented: isPresented, isModal: isModal, transition: transition, style: style, content: content))
+        background(FullscreenView(isPresented: isPresented, isModal: isModal, transition: transition, style: style, onDismiss: onDismiss, content: content))
     }
 
     /// Behaves similarly to `fullScreenCover` but if works on iOS 13+.
@@ -42,7 +42,7 @@ public extension View {
             }
         )
 
-        return background(FullscreenView(isPresented: binding, isModal: isModal, transition: transition, style: style, content: {
+        return background(FullscreenView(isPresented: binding, isModal: isModal, transition: transition, style: style, onDismiss: onDismiss, content: {
             content(item.wrappedValue!)
         }))
     }


### PR DESCRIPTION
I noticed my onDismiss wasn't called when I used `.present(isPresented: $showOverlay, style: .overFullscreen, onDismiss: reset) { ... }` this PR addresses that by passing `onDismiss` to `FullscreenView` and from `FullscreenView` to `FullscreenWrapper` then calling `onDismiss` in the `onDismiss` closure passed to:
```
func viewController<V: View>(rootView: V, isModal: Bool, transition: UIModalTransitionStyle, style: UIModalPresentationStyle, onDismiss: (() -> Void)?) -> UIViewController
```
